### PR TITLE
Improved API Keys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>0.1.3-SNAPSHOT</version>
+      <version>0.2.1-SNAPSHOT</version>
     </dependency>
 
     <!-- Only needed for AwsParamStore -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-rtac</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - Real Time Availability Check</name>

--- a/src/main/java/org/folio/edge/rtac/RtacHandler.java
+++ b/src/main/java/org/folio/edge/rtac/RtacHandler.java
@@ -56,8 +56,8 @@ public class RtacHandler {
       final RtacOkapiClient client = ocf.getRtacOkapiClient(clientInfo.tenantId);
 
       // get token via cache or logging in
-      CompletableFuture<String> tokenFuture = iuHelper.getToken(client, 
-          clientInfo.clientId, 
+      CompletableFuture<String> tokenFuture = iuHelper.getToken(client,
+          clientInfo.clientId,
           clientInfo.tenantId,
           clientInfo.username);
       if (tokenFuture.isCompletedExceptionally()) {

--- a/src/main/java/org/folio/edge/rtac/RtacHandler.java
+++ b/src/main/java/org/folio/edge/rtac/RtacHandler.java
@@ -8,6 +8,8 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.log4j.Logger;
 import org.folio.edge.core.InstitutionalUserHelper;
+import org.folio.edge.core.InstitutionalUserHelper.MalformedApiKeyException;
+import org.folio.edge.core.model.ClientInfo;
 import org.folio.edge.core.security.SecureStore;
 import org.folio.edge.core.utils.Mappers;
 import org.folio.edge.rtac.model.Holdings;
@@ -43,16 +45,21 @@ public class RtacHandler {
     if (id == null || id.isEmpty() || key == null || key.isEmpty()) {
       returnEmptyResponse(ctx);
     } else {
-      String tenant = iuHelper.getTenant(key);
-      if (tenant == null) {
+      ClientInfo clientInfo;
+      try {
+        clientInfo = InstitutionalUserHelper.parseApiKey(key);
+      } catch (MalformedApiKeyException e) {
         returnEmptyResponse(ctx);
         return;
       }
 
-      final RtacOkapiClient client = ocf.getRtacOkapiClient(tenant);
+      final RtacOkapiClient client = ocf.getRtacOkapiClient(clientInfo.tenantId);
 
       // get token via cache or logging in
-      CompletableFuture<String> tokenFuture = iuHelper.getToken(client, tenant, tenant);
+      CompletableFuture<String> tokenFuture = iuHelper.getToken(client, 
+          clientInfo.clientId, 
+          clientInfo.tenantId,
+          clientInfo.username);
       if (tokenFuture.isCompletedExceptionally()) {
         returnEmptyResponse(ctx);
       } else {

--- a/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
@@ -16,11 +16,11 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 
 import org.apache.http.HttpHeaders;
 import org.apache.log4j.Logger;
+import org.folio.edge.core.InstitutionalUserHelper;
 import org.folio.edge.core.utils.test.TestUtils;
 import org.folio.edge.rtac.model.Holdings;
 import org.folio.edge.rtac.utils.RtacMockOkapi;
@@ -43,9 +43,9 @@ public class MainVerticleTest {
   private static final Logger logger = Logger.getLogger(MainVerticleTest.class);
 
   private static final String titleId = "0c8e8ac5-6bcc-461e-a8d3-4b55a96addc8";
-  private static final String apiKey = "ZGlrdQ==";
+  private static final String apiKey = "Z1luMHVGdjNMZl9kaWt1X2Rpa3U=";
   private static final String badApiKey = "ZnMwMDAwMDAwMA==0000";
-  private static final String unknownTenantApiKey = "Ym9ndXN0ZW5hbnQ=";
+  private static final String unknownTenantApiKey = "Z1luMHVGdjNMZl9ib2d1c19ib2d1cw==";
 
   private static final long requestTimeoutMs = 3000L;
 
@@ -58,7 +58,7 @@ public class MainVerticleTest {
     int serverPort = TestUtils.getPort();
 
     List<String> knownTenants = new ArrayList<>();
-    knownTenants.add(new String(Base64.getUrlDecoder().decode(apiKey)));
+    knownTenants.add(InstitutionalUserHelper.parseApiKey(apiKey).tenantId);
 
     mockOkapi = spy(new RtacMockOkapi(okapiPort, knownTenants));
     mockOkapi.start(context);


### PR DESCRIPTION
Utilize the new API key format in edge-common-0.2.1-SNAPSHOT...  

Incorporates a salt/clientId and an institutional userId, to make it harder to guess an API key.

e.g. 
```
clientID/salt = gYn0uFv3Lf (random string)
tenantID = fs00000000
username = fs00000000 (same as tenantID)
delim = "_"

apiKey = urlBase64(gYn0uFv3Lf_fs00000000_fs00000000) 
apiKey = Z1luMHVGdjNMZl9mczAwMDAwMDAwX2ZzMDAwMDAwMD=A
```

The benefit of doing this is that the clientId would only be known to us, so even if someone knew the tenantId, and was able to find or guess the institutional user's username, they would still have to guess or brute force the clientID.