### PR TITLE
Some cleanup in preparation for the next release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,2 +1,7 @@
+## 1.0.0 Unreleased
+ * [EDGRERTAC-4](https://issues.folio.org/browse/EDGRTAC-4): Updated the README
+   EDGRTAC JIRA project link
+ * [EDGRESOLV-5](https://issues.folio.org/browse/EDGRTAC-5): Updated the
+   edge-common dependency to v1.0.0
 ## 0.0.1 2018-05-14
  * Initial Commit

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [edge-common](https://github.com/folio-org/edge-common) for a description of
 
 ### Issue tracker
 
-See project [FOLIO](https://issues.folio.org/browse/FOLIO)
+See project [EDGRTAC](https://issues.folio.org/browse/EDGRTAC)
 at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker).
 
 ### Other documentation

--- a/pom.xml
+++ b/pom.xml
@@ -31,21 +31,32 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- the main class -->
     <exec.mainClass>org.folio.edge.rtac.MainVerticle</exec.mainClass>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>3.4.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>3.4.0</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
-      <version>3.4.0</version>
     </dependency>
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
@@ -65,7 +76,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>0.3.4-SNAPSHOT</version>
+      <version>1.0.0</version>
     </dependency>
 
     <!-- Only needed for AwsParamStore -->
@@ -73,6 +84,12 @@
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-ssm</artifactId>
       <version>1.11.313</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -137,7 +154,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>3.2.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -151,47 +167,48 @@
       <artifactId>rest-assured</artifactId>
       <version>2.9.0</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <!-- We specify the Maven compiler plugin as we need to set it to
-          Java 1.8 -->
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.1</version>
-          <configuration>
-            <source>${maven.compiler.source}</source>
-            <target>${maven.compiler.target}</target>
-          </configuration>
-        </plugin>
+    <plugins>
+      <!-- We specify the Maven compiler plugin as we need to set it to
+        Java 1.8 -->
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
+        </configuration>
+      </plugin>
 
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
-          <configuration>
-            <!-- TODO: update to version 3.0.0 and remove useSystemClassLoader
-                 https://issues.folio.org/browse/FOLIO-1609
-                 https://issues.apache.org/jira/browse/SUREFIRE-1588
-            -->
-            <useSystemClassLoader>false</useSystemClassLoader>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.1</version>
+        <configuration>
+          <!-- TODO: update to version 3.0.0 and remove useSystemClassLoader
+               https://issues.folio.org/browse/FOLIO-1609
+               https://issues.apache.org/jira/browse/SUREFIRE-1588
+          -->
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
     <!-- You only need the part below if you want to build your application
       into a fat executable jar. This is a jar that contains all the dependencies
       required to run it, so you can just run it with java -jar -->
-    <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/src/main/resources/ephemeral.properties
+++ b/src/main/resources/ephemeral.properties
@@ -9,5 +9,5 @@ tenants=fs00000000,diku
 # Note: this is intended for development purposes only
 #######################################################
 
-fs00000000={FS00000000_IU_PASSWORD}
-diku={DIKU_IU_PASSWORD}
+fs00000000=fs00000000,{FS00000000_IU_PASSWORD}
+diku=diku,{DIKU_IU_PASSWORD}

--- a/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
@@ -34,6 +34,7 @@ import com.jayway.restassured.response.Response;
 
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
@@ -82,6 +83,7 @@ public class MainVerticleTest {
   @AfterClass
   public static void tearDownOnce(TestContext context) {
     logger.info("Shutting down server");
+    final Async async = context.async();
     vertx.close(res -> {
       if (res.failed()) {
         logger.error("Failed to shut down edge-rtac server", res.cause());
@@ -92,6 +94,7 @@ public class MainVerticleTest {
 
       logger.info("Shutting down mock Okapi");
       mockOkapi.close();
+      async.complete();
     });
   }
 


### PR DESCRIPTION
Completed EDGRTAC-4 and EDGRTAC-5.

Cleaned up the POM file a bit to remove some warnings and add consistency to vertx dependencies. The vertx version remains the same (updating to 3.5.4 caused some problems with tests that will need to be looked into).

Added an async on the `MainVerticleTest` shutdown so it will complete within the test context. However, the mock Okapi server will still not complete its shutdown within the context of the test. This is addressed in edge-common 1.0.1. This is also true for `RtacOkapiClientTest` which makes use of the mock Okapi server.

The `ephemeral.properties` had to be updated to support the modified format required by 1.0.0 edge-common.