### PR TITLE
EDGRTAC-3, EDGRTAC-7 and EDGRTAC-8

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -5,7 +5,11 @@
   "requires": [
     {
       "id": "rtac",
-      "version": "1.1"
+      "version": "1.2"
+    },
+    {
+      "id": "login",
+      "version": "5.0"
     }
   ],
   "permissionSets": [],

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>1.0.0</version>
+      <version>2.0.0</version>
     </dependency>
 
     <!-- Only needed for AwsParamStore -->

--- a/ramls/edge-rtac.raml
+++ b/ramls/edge-rtac.raml
@@ -1,4 +1,4 @@
-#%RAML 0.8
+#%RAML 1.0
 title: Edge API - Real Time Availability Check
 baseUri: https://github.com/folio-org/edge-rtac
 version: v1
@@ -8,7 +8,7 @@ documentation:
     content: Edge API to interface with FOLIO for 3rd party discovery services to determine holdings availability
 
 schemas:
-  - holdings: !include holdings.xsd
+  holdings: !include holdings.xsd
 
 /prod/rtac/folioRTAC:
   displayName: RTAC
@@ -19,7 +19,7 @@ schemas:
         description: "Success"
         body:
           application/xml:
-            schema: holdings
+            type: holdings
     queryParameters:
       mms_id:
         description: "The UUID of a FOLIO instance"

--- a/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
@@ -44,9 +44,9 @@ public class MainVerticleTest {
   private static final Logger logger = Logger.getLogger(MainVerticleTest.class);
 
   private static final String titleId = "0c8e8ac5-6bcc-461e-a8d3-4b55a96addc8";
-  private static final String apiKey = "Z1luMHVGdjNMZl9kaWt1X2Rpa3U=";
-  private static final String badApiKey = "ZnMwMDAwMDAwMA==0000";
-  private static final String unknownTenantApiKey = "Z1luMHVGdjNMZl9ib2d1c19ib2d1cw==";
+  private static final String apiKey = ApiKeyUtils.generateApiKey(10, "diku", "diku");
+  private static final String badApiKey = apiKey + "0000";
+  private static final String unknownTenantApiKey = ApiKeyUtils.generateApiKey(10, "bogus", "diku");;
 
   private static final long requestTimeoutMs = 3000L;
 
@@ -93,7 +93,7 @@ public class MainVerticleTest {
       }
 
       logger.info("Shutting down mock Okapi");
-      mockOkapi.close();
+      mockOkapi.close(context);
       async.complete();
     });
   }

--- a/src/test/java/org/folio/edge/rtac/utils/RtacOkapiClientTest.java
+++ b/src/test/java/org/folio/edge/rtac/utils/RtacOkapiClientTest.java
@@ -51,7 +51,7 @@ public class RtacOkapiClientTest {
 
   @After
   public void tearDown(TestContext context) {
-    mockOkapi.close();
+    mockOkapi.close(context);
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Combining a few stories into a single PR as they're all fairly small...
* [EDGRTAC-8](https://issues.folio.org/browse/EDGRTAC-8) - Update the required interfaces in the module descriptor
* [EDGRTAC-7](https://issues.folio.org/browse/EDGRTAC-7) - Upgrade edge-common dependency to v2.0.0
* [EDGRTAC-3](https://issues.folio.org/browse/EDGRTAC-3) - Upgrade to RAML 1.0

## Approach
* Update the required interfaces in the module descriptor
  * Add `login 5.0`
  * Upgrade to `rtac 1.2`
* Upgrade edge-common dependency to v2.0.0
  * Update `pom.xml`
  * Make necessary changes to unit tests
* RAML 1.0
  * Make changes as per https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md
  * Verify changes using lint_ramlcop in folio-org/folio-tools