### PR TITLE
EDGRTAC-11: pass the new "volume" field to the caller

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -5,7 +5,7 @@
   "requires": [
     {
       "id": "rtac",
-      "version": "1.2"
+      "version": "1.3"
     },
     {
       "id": "login",

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.1</version>
     </dependency>
 
     <!-- Only needed for AwsParamStore -->

--- a/ramls/holdings.xsd
+++ b/ramls/holdings.xsd
@@ -18,6 +18,7 @@
       <xs:element name="status" type="xs:string"/>
       <xs:element name="dueDate" type="xs:string"/>
       <xs:element name="tempLocation" type="xs:string" minOccurs="0"/>
+      <xs:element name="volume" type="xs:string" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>
 </xs:element>

--- a/src/main/java/org/folio/edge/rtac/model/Holdings.java
+++ b/src/main/java/org/folio/edge/rtac/model/Holdings.java
@@ -71,14 +71,16 @@ public final class Holdings {
     public final String status;
     public final String dueDate;
     public final String tempLocation;
+    public final String volume;
 
-    private Holding(String id, String callNumber, String location, String status, String dueDate, String tempLocation) {
+    private Holding(String id, String callNumber, String location, String status, String dueDate, String tempLocation, String volume) {
       this.id = id;
       this.callNumber = callNumber;
       this.location = location;
       this.status = status;
       this.dueDate = dueDate;
       this.tempLocation = tempLocation;
+      this.volume = volume;
     }
 
     public static Builder builder() {
@@ -92,6 +94,7 @@ public final class Holdings {
       private String status;
       private String dueDate;
       private String tempLocation;
+      private String volume;
 
       @JsonProperty("id")
       public Builder id(String id) {
@@ -129,8 +132,14 @@ public final class Holdings {
         return this;
       }
 
+      @JsonProperty("volume")
+      public Builder volume(String volume) {
+        this.volume = volume;
+        return this;
+      }
+
       public Holding build() {
-        return new Holding(id, callNumber, location, status, dueDate, tempLocation);
+        return new Holding(id, callNumber, location, status, dueDate, tempLocation, volume);
       }
     }
 
@@ -145,6 +154,7 @@ public final class Holdings {
       result = prime * result + ((location == null) ? 0 : location.hashCode());
       result = prime * result + ((status == null) ? 0 : status.hashCode());
       result = prime * result + ((tempLocation == null) ? 0 : tempLocation.hashCode());
+      result = prime * result + ((volume == null) ? 0 : volume.hashCode());
       return result;
     }
 
@@ -201,6 +211,13 @@ public final class Holdings {
           return false;
         }
       } else if (!tempLocation.equals(other.tempLocation)) {
+        return false;
+      }
+      if (volume == null) {
+        if (other.volume != null) {
+          return false;
+        }
+      } else if (!volume.equals(other.volume)) {
         return false;
       }
       return true;

--- a/src/test/java/org/folio/edge/rtac/model/HoldingsTest.java
+++ b/src/test/java/org/folio/edge/rtac/model/HoldingsTest.java
@@ -39,6 +39,7 @@ public class HoldingsTest {
       .location("LC General Collection Millersville University Library")
       .status("Item in place")
       .dueDate("")
+      .volume("v.10:no.2")
       .build();
 
     Holding h2 = Holding.builder()

--- a/src/test/java/org/folio/edge/rtac/utils/RtacMockOkapi.java
+++ b/src/test/java/org/folio/edge/rtac/utils/RtacMockOkapi.java
@@ -67,6 +67,7 @@ public class RtacMockOkapi extends MockOkapi {
       .status("Item in place")
       .tempLocation("")
       .dueDate("")
+      .volume("v.5:no.2-6")
       .build();
 
     Holdings holdings = new Holdings();


### PR DESCRIPTION
The `rtac` interface now returns `volume`, which contains the FOLIO item `enumeration` field data. This will be used to distinguish titles that are part of a series. We are now dependent of v1.3 of the `rtac` interface.