### PR TITLE
EDGRTAC-12 and EDGRTAC-13 (compression and login version)

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -9,7 +9,7 @@
     },
     {
       "id": "login",
-      "version": "5.0"
+      "version": "5.0 6.0"
     }
   ],
   "permissionSets": [],

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>2.0.1</version>
+      <version>2.0.2</version>
     </dependency>
 
     <!-- Only needed for AwsParamStore -->
@@ -308,7 +308,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
         <configuration>
           <preparationGoals>clean verify</preparationGoals>
           <tagNameFormat>v@{project.version}</tagNameFormat>
@@ -317,6 +316,20 @@
         </configuration>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <!--
+           The super pom declares these dependencies and versions. Eclipse warns when versions
+           are specified for plugins that are controlled by pluginManagement. By declaring them
+           here we avoid these warnings and ensure we are getting the expected versions, in case
+           the super pom changes versions for some reason.
+      -->
+      <plugins>
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <repositories>

--- a/src/test/java/org/folio/edge/rtac/utils/RtacOkapiClientCompressionTest.java
+++ b/src/test/java/org/folio/edge/rtac/utils/RtacOkapiClientCompressionTest.java
@@ -1,0 +1,77 @@
+package org.folio.edge.rtac.utils;
+
+import java.util.UUID;
+
+import org.apache.log4j.Logger;
+import org.folio.edge.core.utils.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class RtacOkapiClientCompressionTest {
+  private static final Logger logger = Logger.getLogger(RtacOkapiClientCompressionTest.class);
+
+  private final Vertx vertx = Vertx.vertx();
+
+  private final String titleId = UUID.randomUUID().toString();
+  private static final String tenant = "diku";
+  private static final long reqTimeout = 3000L;
+
+  private RtacOkapiClient client;
+
+  @Before
+  public void setUp(TestContext context) throws Exception {
+    int okapiPort = TestUtils.getPort();
+
+    final HttpServer server = vertx.createHttpServer(
+        new HttpServerOptions().setCompressionSupported(true));
+
+    server.requestHandler(req -> {
+      req.response()
+        .setStatusCode(200)
+        .putHeader("content-type", "application/json")
+        .end("{\"test\":\"1234\"}");
+    });
+
+    final Async async = context.async();
+    server.listen(okapiPort, "localhost", ar -> {
+      context.assertTrue(ar.succeeded());
+      async.complete();
+    });
+
+    client = new RtacOkapiClientFactory(vertx,
+        "http://localhost:" + okapiPort, reqTimeout).getRtacOkapiClient(tenant);
+  }
+
+  @After
+  public void tearDown(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
+  }
+
+  @Test
+  public void testCompression(TestContext context) throws Exception {
+    logger.info("=== Test Compression ===");
+
+    MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+    headers.add("Accept-Encoding", "gzip");
+    Async async = context.async();
+    client.rtac(titleId, headers).thenAccept(body -> {
+      logger.info("mod-rtac response body: " + body);
+      context.assertEquals("{\"test\":\"1234\"}", body.toString());
+      async.complete();
+    }).exceptionally(t -> {
+      context.fail(t);
+      return null;
+    });
+  }
+}

--- a/src/test/java/org/folio/edge/rtac/utils/RtacOkapiClientCompressionTest.java
+++ b/src/test/java/org/folio/edge/rtac/utils/RtacOkapiClientCompressionTest.java
@@ -58,6 +58,15 @@ public class RtacOkapiClientCompressionTest {
     vertx.close(context.asyncAssertSuccess());
   }
 
+  /**
+   * This test will ensure that if compression is requested via the "Accept-Encoding" header and
+   * the server responds with compressed data, then the edge-common Okapi client will be able to
+   * decompress the data before it is available for use by the handlers. Test failure here
+   * indicates that compression is not working via edge-common.
+   *
+   * @param context test context
+   * @throws Exception unexpected failure
+   */
   @Test
   public void testCompression(TestContext context) throws Exception {
     logger.info("=== Test Compression ===");


### PR DESCRIPTION
Update the `login` interface version to include `6.0`.

Use `edge-common` 2.0.2 to enable compression support. Added a test that will work with 2.0.2 but not <2.0.1 and will break if someone messes with compression in edge-common.