### PR TITLE
Upgrade log4j to version 2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,24 +109,32 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.18</version>
-    </dependency>
-
-    <!-- we use log4j as our logging implementation -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
       <version>1.7.30</version>
     </dependency>
+    <!-- we use log4j as our logging implementation -->
+    <!--
+      The Log4j 2 SLF4J Binding allows applications coded to the SLF4J API to use Log4j 2 as the implementation.
+
+      Due to a break in compatibility in the SLF4J binding, as of release 2.11.1 two SLF4J to Log4j Adapters are provided.
+
+      log4j-slf4j-impl should be used with SLF4J 1.7.x releases or older.
+      log4j-slf4j18-impl should be used with SLF4J 1.8.x releases or newer.
+      Applications that take advantage of the Java Module System should use SLF4J 1.8.x and log4j-slf4j18-impl.
+
+      The Log4j 2 SLF4J Binding has a dependency on the Log4j 2 API as well as the SLF4J API
+    -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
+      <artifactId>log4j-slf4j-impl</artifactId>
       <version>2.13.3</version>
     </dependency>
+    <!-- Log4j implementation of Log4j2 -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>2.13.3</version>
+      <artifactId>log4j-bom</artifactId>
+      <version>2.12.1</version>
+      <scope>import</scope>
+      <type>pom</type>
     </dependency>
 
     <!-- include slf4j bridges to proxy all logging from library deps to
@@ -198,8 +206,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.1</version>
+        <version>2.22.2</version>
         <configuration>
+          <systemPropertyVariables>
+            <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.Log4j2LogDelegateFactory</vertx.logger-delegate-factory-class-name>
+          </systemPropertyVariables>
           <!-- TODO: update to version 3.0.0 and remove useSystemClassLoader
                https://issues.folio.org/browse/FOLIO-1609
                https://issues.apache.org/jira/browse/SUREFIRE-1588

--- a/pom.xml
+++ b/pom.xml
@@ -115,13 +115,18 @@
     <!-- we use log4j as our logging implementation -->
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.13</version>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.30</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.13.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.13.3</version>
     </dependency>
 
     <!-- include slf4j bridges to proxy all logging from library deps to
@@ -129,7 +134,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <version>1.7.18</version>
+      <version>1.7.30</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
 
     <!-- the main class -->
     <exec.mainClass>org.folio.edge.rtac.MainVerticle</exec.mainClass>
+    <slf4j.version>1.7.30</slf4j.version>
+    <log4j2.version>2.13.3</log4j2.version>
   </properties>
 
   <dependencyManagement>
@@ -109,7 +111,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
+      <version>${slf4j.version}</version>
     </dependency>
     <!-- we use log4j as our logging implementation -->
     <!--
@@ -126,13 +128,13 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.13.3</version>
+      <version>${log4j2.version}</version>
     </dependency>
     <!-- Log4j implementation of Log4j2 -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-bom</artifactId>
-      <version>2.12.1</version>
+      <version>${log4j2.version}</version>
       <scope>import</scope>
       <type>pom</type>
     </dependency>
@@ -142,7 +144,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <version>1.7.30</version>
+      <version>${slf4j.version}</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
Fix security vulnerability reported in log4j 1.2 (EDGRTAC-26)
https://issues.folio.org/browse/EDGRTAC-26