### PR TITLE
EDGRTAC-33: Fix a memory leak in edge-rtac

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>2.0.2</version>
+      <version>3.0.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Purpose 

Fix a memory leak in edge-rtac

## Approach

Update edge-commons version where the memory leak is fixed

Jiras: 
https://issues.folio.org/browse/EDGRTAC-33
https://issues.folio.org/browse/EDGCOMMON-25 - memory leak fix

