### PR TITLE
EDGRTAC-43: Instance ID number not included in JSON response when instance not found

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # 2.3.0 IN-PROGRESS
 
 * Upgrade to vert.x 4.x (EDGRTAC-37)
-* Instance ID number is now included in Json responses in which holdings data could not be found or reported (EDGRTAC-43)
+* Instance ID number is now included in responses in which holdings data could not be found or reported (EDGRTAC-43)
 
 # 2.2.0 2021-03-16
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # 2.3.0 IN-PROGRESS
 
 * Upgrade to vert.x 4.x (EDGRTAC-37)
-* Instance ID number is now included in all responses in which holdings data could not be found or reported (EDGRTAC-43)
+* Instance ID number is now included in Json responses in which holdings data could not be found or reported (EDGRTAC-43)
 
 # 2.2.0 2021-03-16
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # 2.3.0 IN-PROGRESS
 
 * Upgrade to vert.x 4.x (EDGRTAC-37)
+* Instance ID number is now included in all responses in which holdings data could not be found or reported (EDGRTAC-43)
 
 # 2.2.0 2021-03-16
 

--- a/src/main/java/org/folio/edge/rtac/RtacHandler.java
+++ b/src/main/java/org/folio/edge/rtac/RtacHandler.java
@@ -103,7 +103,7 @@ public class RtacHandler extends Handler {
                 returningContent = isXmlRequest ? instances.toXml() : instances.toJson();
               } else {
                 var holdings = new Holdings();
-                if (instances.getHoldings().isEmpty() && !isXmlRequest) {
+                if (instances.getHoldings().isEmpty()) {
                   holdings.setInstanceId(request.params().get("instanceId"));
                 }
                 if (!instances.getHoldings().isEmpty()) {

--- a/src/main/java/org/folio/edge/rtac/RtacHandler.java
+++ b/src/main/java/org/folio/edge/rtac/RtacHandler.java
@@ -103,11 +103,12 @@ public class RtacHandler extends Handler {
                 returningContent = isXmlRequest ? instances.toXml() : instances.toJson();
               } else {
                 var holdings = new Holdings();
-                if (instances.getHoldings().isEmpty()) {
+                if (instances.getHoldings().isEmpty() && !isXmlRequest) {
                   holdings.setInstanceId(request.params().get("instanceId"));
-                } else {
-                  holdings = instances.getHoldings().get(0);
                 }
+                if (!instances.getHoldings().isEmpty()) {
+                  holdings = instances.getHoldings().get(0);
+                } 
                 returningContent = isXmlRequest ? holdings.toXml() : holdings.toJson();
               }
 

--- a/src/main/java/org/folio/edge/rtac/RtacHandler.java
+++ b/src/main/java/org/folio/edge/rtac/RtacHandler.java
@@ -106,7 +106,7 @@ public class RtacHandler extends Handler {
                 if (instances.getHoldings().isEmpty()) {
                   holdings.setInstanceId(request.params().get("instanceId"));
                 }
-                if (!instances.getHoldings().isEmpty()) {
+                else {
                   holdings = instances.getHoldings().get(0);
                 } 
                 returningContent = isXmlRequest ? holdings.toXml() : holdings.toJson();

--- a/src/main/java/org/folio/edge/rtac/RtacHandler.java
+++ b/src/main/java/org/folio/edge/rtac/RtacHandler.java
@@ -102,7 +102,12 @@ public class RtacHandler extends Handler {
               if (isBatch) {
                 returningContent = isXmlRequest ? instances.toXml() : instances.toJson();
               } else {
-                var holdings = instances.getHoldings().isEmpty() ? new Holdings() : instances.getHoldings().get(0);
+                var holdings = new Holdings();
+                if (instances.getHoldings().isEmpty()) {
+                  holdings.setInstanceId(request.params().get("instanceId"));
+                } else {
+                  holdings = instances.getHoldings().get(0);
+                }
                 returningContent = isXmlRequest ? holdings.toXml() : holdings.toJson();
               }
 

--- a/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
@@ -418,10 +418,6 @@ public class MainVerticleTest {
   @Test
   @SneakyThrows
   public void testResponseShouldIncludeInstanceIdWhenTitleNotFoundAndReturnsJson() {
-    Holdings exp = new Holdings();
-    exp.setInstanceId(RtacMockOkapi.titleId_notFound);
-    String expected = exp.toJson().toString();
-    
     final Response resp = RestAssured
       .given()
       .accept(APPLICATION_JSON)
@@ -434,6 +430,11 @@ public class MainVerticleTest {
       .response();
     
     final String actual = resp.body().asString();
+
+    Holdings exp = new Holdings();
+    exp.setInstanceId(RtacMockOkapi.titleId_notFound);
+    String expected = exp.toJson().toString();
+
     assertEquals(expected, actual);
   }
 

--- a/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
@@ -416,6 +416,28 @@ public class MainVerticleTest {
   }
 
   @Test
+  @SneakyThrows
+  public void testResponseShouldIncludeInstanceIdWhenTitleNotFoundAndReturnsJson() {
+    Holdings exp = new Holdings();
+    exp.setInstanceId(RtacMockOkapi.titleId_notFound);
+    String expected = exp.toJson().toString();
+    
+    final Response resp = RestAssured
+      .given()
+      .accept(APPLICATION_JSON)
+      .get(String.format("/rtac/%s?apikey=%s", RtacMockOkapi.titleId_notFound, apiKey))
+      .then()
+      .contentType(APPLICATION_JSON)
+      .statusCode(SC_OK)
+      .header(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
+      .extract()
+      .response();
+    
+    final String actual = resp.body().asString();
+    assertEquals(expected, actual);
+  }
+
+  @Test
   public void shouldRespondWithXMLWhenClientDoesNotStateAPreference() throws IOException {
     final var queryString = prepareQueryFor(apiKey, titleId);
     final var expectedRecords = prepareRecordsFor(titleId);


### PR DESCRIPTION
Solution for this was simple:  I altered the code that constructs the 
response to set the instance ID number in the response if it is empty
(as it is in any response where the instance record could not be found
or retrieved).  Note that this affects the response for *any* situation
in which holdings data could not be retrieved, not just situations
where the instance Id cannot be found.  For example,
I discovered during testing that you get the same response from edge-rtac 
if mod-rtac responds with a 405 error.

Because the original issue asked for this to be added to the json response, 
I had the code check for and not add the number to XML responses.  It did not 
seem to me to be a good idea to make changes to responses that were not 
specifically asked for, given how many pieces of software use this module.