### PR TITLE
EDGRTAC-50: Upgrade to Log4J 2.16.0 (Kiwi R3 2021).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# 2.3.1 2021-12-15
+# 2.3.1 IN-PROGRESS
 
 * Upgrade to Log4J 2.16.0. (CVE-2021-44228) (EDGRTAC-50)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 2.3.1 2021-12-15
+
+* Upgrade to Log4J 2.16.0. (CVE-2021-44228) (EDGRTAC-50)
+
 # 2.3.0 2021-10-05
 
 * Upgrade to vert.x 4.x (EDGRTAC-37)

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <!-- the main class -->
     <exec.mainClass>org.folio.edge.rtac.MainVerticle</exec.mainClass>
-    <log4j2.version>2.13.3</log4j2.version>
+    <log4j2.version>2.16.0</log4j2.version>
     <apache.common.lang.ver>3.11</apache.common.lang.ver>
     <apache.common.collections.ver>4.4</apache.common.collections.ver>
   </properties>


### PR DESCRIPTION
Resolve CVE-2021-44228 as per [EDGRTAC-50](https://issues.folio.org/browse/EDGRTAC-50).