### PR TITLE
EDGRTAC-55: Update Log4j to 2.17.0 (Kiwi R3 2021).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
+# 2.3.2 IN-PROGRESS
+
+* Upgrade to Log4J 2.17.0. (CVE-2021-45105) [EDGRTAC-55](https://issues.folio.org/browse/EDGRTAC-55)
+
 # 2.3.1 2021-12-16
 
-* Upgrade to Log4J 2.16.0. (CVE-2021-44228) (EDGRTAC-50)
+* Upgrade to Log4J 2.16.0. (CVE-2021-44228) [EDGRTAC-50](https://issues.folio.org/browse/EDGRTAC-50)
 
 # 2.3.0 2021-10-05
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <!-- the main class -->
     <exec.mainClass>org.folio.edge.rtac.MainVerticle</exec.mainClass>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
     <apache.common.lang.ver>3.11</apache.common.lang.ver>
     <apache.common.collections.ver>4.4</apache.common.collections.ver>
   </properties>


### PR DESCRIPTION
Resolve CVE-2021-45105 as per [EDGRTAC-55](https://issues.folio.org/browse/EDGRTAC-55).