### PR TITLE
EDGRTAC-57: Update Log4j to 2.17.0 (Juniper R2 2021).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
+# 2.2.2 IN-PROGRESS
+
+* Upgrade to Log4J 2.17.0. (CVE-2021-45105) [EDGRTAC-57](https://issues.folio.org/browse/EDGRTAC-57)
+
 # 2.2.1 2021-12-16
 
-* Upgrade to Log4J 2.16.0. (CVE-2021-44228) (EDGRTAC-52)
+* Upgrade to Log4J 2.16.0. (CVE-2021-44228) [EDGRTAC-52](https://issues.folio.org/browse/EDGRTAC-52)
 
 # 2.2.0 2021-03-16
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <!-- the main class -->
     <exec.mainClass>org.folio.edge.rtac.MainVerticle</exec.mainClass>
     <slf4j.version>1.7.30</slf4j.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
     <apache.common.lang.ver>3.11</apache.common.lang.ver>
     <apache.common.collections.ver>4.4</apache.common.collections.ver>
   </properties>


### PR DESCRIPTION
Resolve CVE-2021-45105 as per [EDGRTAC-57](https://issues.folio.org/browse/EDGRTAC-57).