### PR TITLE
Remove use of vert x completable future EDGRTAC-60

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,6 @@
     <!-- the main class -->
     <exec.mainClass>org.folio.edge.rtac.MainVerticle</exec.mainClass>
     <log4j2.version>2.17.0</log4j2.version>
-    <apache.common.lang.ver>3.11</apache.common.lang.ver>
-    <apache.common.collections.ver>4.4</apache.common.collections.ver>
   </properties>
 
   <dependencyManagement>
@@ -43,7 +41,20 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.1.1</version>
+        <version>4.3.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.13.3</version>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.8.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -70,24 +81,31 @@
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt</artifactId>
-      <version>0.6.0</version>
+      <version>0.9.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.9.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
-      <version>2.9.4</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>4.2.0</version>
+      <version>4.3.0</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <version>4.4</version>
+    </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
@@ -131,9 +149,23 @@
 
     <!-- Test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-junit5</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -148,7 +180,6 @@
       <version>3.4.2</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
@@ -165,16 +196,6 @@
       <artifactId>rest-assured</artifactId>
       <version>4.3.0</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>${apache.common.lang.ver}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-      <version>${apache.common.collections.ver}</version>
     </dependency>
   </dependencies>
 
@@ -196,11 +217,6 @@
           <systemPropertyVariables>
             <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.Log4j2LogDelegateFactory</vertx.logger-delegate-factory-class-name>
           </systemPropertyVariables>
-           <!-- TODO: update to version 3.0.0 and remove useSystemClassLoader
-               https://issues.folio.org/browse/FOLIO-1609
-               https://issues.apache.org/jira/browse/SUREFIRE-1588
-          -->
-          <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
       </plugin>
     <!-- You only need the part below if you want to build your application

--- a/src/main/java/org/folio/edge/rtac/utils/RtacOkapiClient.java
+++ b/src/main/java/org/folio/edge/rtac/utils/RtacOkapiClient.java
@@ -13,6 +13,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.Value;
 
 public class RtacOkapiClient extends OkapiClient {
@@ -47,7 +48,7 @@ public class RtacOkapiClient extends OkapiClient {
     logger.error("Exception when calling mod-rtac: {}", t.getMessage());
   }
 
-  @Value
+  @Getter
   @AllArgsConstructor
   static class Response {
     int statusCode;

--- a/src/main/java/org/folio/edge/rtac/utils/RtacOkapiClient.java
+++ b/src/main/java/org/folio/edge/rtac/utils/RtacOkapiClient.java
@@ -6,12 +6,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.utils.OkapiClient;
 
-import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
 
 public class RtacOkapiClient extends OkapiClient {
@@ -22,7 +21,7 @@ public class RtacOkapiClient extends OkapiClient {
   public RtacOkapiClient(OkapiClient client) {
     super(client);
   }
-
+ 
   protected RtacOkapiClient(Vertx vertx, String okapiURL, String tenant, int timeout) {
     super(vertx, okapiURL, tenant, timeout);
   }
@@ -32,36 +31,37 @@ public class RtacOkapiClient extends OkapiClient {
   }
 
   public CompletableFuture<String> rtac(String requestBody, MultiMap headers) {
-    final Promise<String> promise = Promise.promise();
+    final Promise<HttpResponse<Buffer>> promise = Promise.promise();
 
-    post(
-        okapiURL + RTAC_API_URI,
-        tenant,
-        requestBody,
-        combineHeadersWithDefaults(headers),
-        response -> {
-          int statusCode = response.statusCode();
-          String responseBody = response.body().toString();
-          if (statusCode == 200) {
-            logger.info(String.format(
-                "Successfully retrieved title info from mod-rtac: (%s) %s",
-                statusCode,
-                responseBody));
-            promise.complete(responseBody);
-          } else {
-            String err = String.format(
-                "Failed to get title info from mod-rtac: (%s) %s",
-                response.statusCode(),
-                responseBody);
-            logger.error(err);
-            promise.complete("{}");
-          }
-        },
-        t -> {
-          logger.error("Exception when calling mod-rtac: {}", t.getMessage());
-          promise.fail(t);
-        });
+    post(okapiURL + RTAC_API_URI, tenant, requestBody,
+      combineHeadersWithDefaults(headers), promise::complete, promise::fail);
 
-    return promise.future().toCompletionStage().toCompletableFuture();
+    return promise.future()
+      .map(RtacOkapiClient::interpretResponse)
+      .onFailure(RtacOkapiClient::logError)
+      .toCompletionStage().toCompletableFuture();
+  }
+
+  private static void logError(Throwable t) {
+    logger.error("Exception when calling mod-rtac: {}", t.getMessage());
+  }
+
+  private static String interpretResponse(HttpResponse<Buffer> response) {
+    int statusCode = response.statusCode();
+    String responseBody = response.body().toString();
+
+    if (statusCode == 200) {
+      logger.info("Successfully retrieved title info from mod-rtac: ({}) {}",
+        statusCode, responseBody);
+
+      return responseBody;
+    } else {
+      logger.error(
+          "Failed to get title info from mod-rtac: ({}) {}",
+          response.statusCode(), responseBody);
+
+      // Failure is converted to empty response
+      return new JsonObject().encode();
+    }
   }
 }

--- a/src/test/java/org/folio/edge/rtac/utils/RtacClientResponseInterpreterTests.java
+++ b/src/test/java/org/folio/edge/rtac/utils/RtacClientResponseInterpreterTests.java
@@ -1,0 +1,26 @@
+package org.folio.edge.rtac.utils;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class RtacClientResponseInterpreterTests {
+  @Test
+  void successfulResponseIsMappedToBody() {
+    final var responseInterpreter = new RtacOkapiClient.ResponseInterpreter();
+
+    final var response = new RtacOkapiClient.Response(200, "some body");
+
+    assertThat(responseInterpreter.interpretResponse(response), is("some body"));
+  }
+
+  @Test
+  void failureResponseIsMappedToEmptyJson() {
+    final var responseInterpreter = new RtacOkapiClient.ResponseInterpreter();
+
+    final var response = new RtacOkapiClient.Response(400, "irrelevant");
+
+    assertThat(responseInterpreter.interpretResponse(response), is("{}"));
+  }
+}

--- a/src/test/java/org/folio/edge/rtac/utils/RtacOkapiClientTest.java
+++ b/src/test/java/org/folio/edge/rtac/utils/RtacOkapiClientTest.java
@@ -36,7 +36,6 @@ import lombok.SneakyThrows;
 
 @RunWith(VertxUnitRunner.class)
 public class RtacOkapiClientTest {
-
   private static final Logger logger = LogManager.getLogger(RtacOkapiClientTest.class);
 
   private final String titleId = "0c8e8ac5-6bcc-461e-a8d3-4b55a96addc8";
@@ -47,7 +46,7 @@ public class RtacOkapiClientTest {
   private RtacMockOkapi mockOkapi;
 
   @Before
-  public void setUp(TestContext context) throws Exception {
+  public void setUp(TestContext context) {
     int okapiPort = TestUtils.getPort();
 
     List<String> knownTenants = new ArrayList<>();
@@ -102,13 +101,12 @@ public class RtacOkapiClientTest {
       .map(String::trim).collect(toList());
 
     rtacParams.put("instanceIds", ids);
-    var instanceIds = Mappers.jsonMapper
+    return Mappers.jsonMapper
       .writeValueAsString(rtacParams);
-    return instanceIds;
   }
 
   @Test
-  public void testRtacTimeout(TestContext context) throws Exception {
+  public void testRtacTimeout(TestContext context) {
     logger.info("=== Test RTAC timeout ===");
 
     MultiMap headers = MultiMap.caseInsensitiveMultiMap();

--- a/src/test/java/org/folio/edge/rtac/utils/RtacOkapiClientTest.java
+++ b/src/test/java/org/folio/edge/rtac/utils/RtacOkapiClientTest.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeoutException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;


### PR DESCRIPTION
*Purpose*

Remove vert.x completable future library that is no longer needed since upgrade to vert.x 4.0

*Approach*
* Replace the use of vert.x completable future with vert.x promise
* Use promise handlers to simplify the response handling
* Upgrade to edge-common 4.3.0 to remove transient dependency
* Extract response interpretation to allow for unit tests