### PR TITLE
EDGRTAC-64: Replace equality comparisons with explicit assertions

### DIFF
--- a/src/main/java/org/folio/edge/rtac/model/Holdings.java
+++ b/src/main/java/org/folio/edge/rtac/model/Holdings.java
@@ -31,8 +31,16 @@ public final class Holdings {
     this.instanceId = instanceId;
   }
 
+  public String getInstanceId() {
+    return this.instanceId;
+  }
+
   public void setHoldings(List<Holding> holdings) {
     this.holdings = holdings;
+  }
+
+  public List<Holding> getHoldings() {
+    return this.holdings;
   }
 
   public String toXml() throws JsonProcessingException {

--- a/src/main/java/org/folio/edge/rtac/model/Instances.java
+++ b/src/main/java/org/folio/edge/rtac/model/Instances.java
@@ -33,11 +33,6 @@ public final class Instances {
   @JacksonXmlElementWrapper(localName = "errors")
   private List<Error> errors = null;
 
-  @JsonProperty("InstanceId")
-  @JacksonXmlProperty(localName = "instanceId")
-  @JacksonXmlElementWrapper(localName = "instanceId")
-  private String instanceId = null;
-
   public void setErrors(List<Error> errors) {
     this.errors = errors;
   }

--- a/src/main/java/org/folio/edge/rtac/model/Instances.java
+++ b/src/main/java/org/folio/edge/rtac/model/Instances.java
@@ -33,6 +33,11 @@ public final class Instances {
   @JacksonXmlElementWrapper(localName = "errors")
   private List<Error> errors = null;
 
+  @JsonProperty("InstanceId")
+  @JacksonXmlProperty(localName = "instanceId")
+  @JacksonXmlElementWrapper(localName = "instanceId")
+  private String instanceId = null;
+
   public void setErrors(List<Error> errors) {
     this.errors = errors;
   }

--- a/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
@@ -174,7 +174,6 @@ public class MainVerticleTest {
       .response();
 
     expectEmptyResponseOnFailure(resp);
-
   }
 
   @Test
@@ -217,7 +216,6 @@ public class MainVerticleTest {
     assertEquals("PS3552.E796 D44x 1975", holdingRecord.getString("callNumber"));
     assertEquals("Item in place", holdingRecord.getString("status"));
     assertEquals("v.5:no.2-6", holdingRecord.getString("volume"));
-
   }
 
   // Unsuccessful searches result in a 200 OK status with an empty element in the 
@@ -305,7 +303,6 @@ public class MainVerticleTest {
 
     assertEquals(expectedError, errors.getString("message"));
     assertEquals("404", errors.getString("code"));
-
   }
 
   @Test
@@ -400,7 +397,6 @@ public class MainVerticleTest {
       assertEquals("99712686103569", holdings.getString("id"));
       assertEquals("Item in place", holdings.getString("status"));
       assertEquals("v.5:no.2-6", holdings.getString("volume"));
-
     }
 
     verify(mockOkapi).loginHandler(any());
@@ -482,7 +478,6 @@ public class MainVerticleTest {
     assertEquals("PS3552.E796 D44x 1975", holding.callNumber);
     assertEquals("Item in place", holding.status);
     assertEquals("v.5:no.2-6", holding.volume);
-
   }
 
   @Test

--- a/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
@@ -153,6 +153,9 @@ public class MainVerticleTest {
     assertEquals("\"OK\"", resp.body().asString());
   }
 
+  // unsuccessful login attempts result in a 200 OK status with an empty element 
+  // in the message body
+
   @Test
   public void testRtacUnknownApiKey(TestContext context) throws Exception {
     logger.info("=== Test request with unknown apiKey (tenant) ===");
@@ -207,6 +210,9 @@ public class MainVerticleTest {
     var actual = Holdings.fromXml(xml);
     assertEquals(expected, actual);
   }
+
+  // Unsuccessful searches result in a 200 OK status with an empty element in the 
+  // response body 
 
   @Test
   public void testRtacTitleNotFound(TestContext context) throws Exception {


### PR DESCRIPTION
Because it's a lot easier to do explicit assertions with JSON, I switched
Most of the tests over to requesting and parsing JSON, rather than XML.

Because so many of the tests now request json only, I removed the test that 
checks to see if a request gets JSON if it asks for JSON only-this now seems redundant.

I'm at a bit of a loss as to what to do about the xml tests that remain.  From looking at the 
XML library this module seems to use (jackson-dataformat-xml), you can really only do
testing of xml two ways: either dump the entire structure it to a string and compare 
to another string (which I think is not a good idea), or serialize it into a java object 
and compare it to another object (which is what the tests are already doing).  If the 
objects in question had getter methods I could use to access underlying data I would 
do that, but they don't seem to have those structures, and I'm not sure I should 
try to add them.

So I have left the XML tests largely alone.

