### PR TITLE
Remove redundant equality methods for instances and holdings EDGRTAC-64

### DIFF
--- a/src/main/java/org/folio/edge/rtac/model/Holdings.java
+++ b/src/main/java/org/folio/edge/rtac/model/Holdings.java
@@ -1,9 +1,7 @@
 package org.folio.edge.rtac.model;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import org.folio.edge.core.utils.Mappers;
 
@@ -49,24 +47,5 @@ public final class Holdings {
 
   public String toJson() throws JsonProcessingException {
     return Mappers.jsonMapper.writeValueAsString(this);
-  }
-
-  public static Holdings fromXml(String xml) throws IOException {
-    return Mappers.xmlMapper.readValue(xml, Holdings.class);
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    Holdings holdings1 = (Holdings) o;
-
-    return holdings.equals(holdings1.holdings) &&
-      Objects.equals(instanceId, holdings1.instanceId);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(holdings, instanceId);
   }
 }

--- a/src/main/java/org/folio/edge/rtac/model/Instances.java
+++ b/src/main/java/org/folio/edge/rtac/model/Instances.java
@@ -3,7 +3,6 @@ package org.folio.edge.rtac.model;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import org.folio.edge.core.utils.Mappers;
 
@@ -56,20 +55,6 @@ public final class Instances {
 
   public static Instances fromXml(String xml) throws IOException {
     return Mappers.xmlMapper.readValue(xml, Instances.class);
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    Instances instances = (Instances) o;
-    return Objects.equals(holdings, instances.holdings) &&
-      Objects.equals(errors, instances.errors);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(holdings, errors);
   }
 }
 


### PR DESCRIPTION
Following on from the changes to make the test expectations explicit and not rely on equality comparison, these methods can now be removed from the production code.