### PR TITLE
EDGRTAC-68: edge-common 4.4.1 fixing disabled SSL in Vert.x WebClient 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <!-- the main class -->
     <exec.mainClass>org.folio.edge.rtac.MainVerticle</exec.mainClass>
-    <log4j2.version>2.17.0</log4j2.version>
+    <log4j2.version>2.18.0</log4j2.version>
   </properties>
 
   <dependencyManagement>
@@ -41,7 +41,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.3.1</version>
+        <version>4.3.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>4.3.0</version>
+      <version>4.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
@@ -15,7 +15,6 @@ import static org.apache.http.HttpStatus.SC_OK;
 import static org.folio.edge.rtac.utils.RtacUtils.composeMimeTypes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.spy;
@@ -37,7 +36,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.utils.ApiKeyUtils;
 import org.folio.edge.core.utils.test.TestUtils;
-import org.folio.edge.rtac.model.Error;
 import org.folio.edge.rtac.model.Holding;
 import org.folio.edge.rtac.model.Holdings;
 import org.folio.edge.rtac.model.Instances;
@@ -53,7 +51,6 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.Vertx;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import lombok.SneakyThrows;
@@ -82,7 +79,7 @@ public class MainVerticleTest {
     knownTenants.add(ApiKeyUtils.parseApiKey(apiKey).tenantId);
 
     mockOkapi = spy(new RtacMockOkapi(okapiPort, knownTenants));
-    mockOkapi.start(context);
+    mockOkapi.start().onComplete(context.asyncAssertSuccess());
 
     vertx = Vertx.vertx();
 
@@ -103,19 +100,7 @@ public class MainVerticleTest {
   @AfterClass
   public static void tearDownOnce(TestContext context) {
     logger.info("Shutting down server");
-    final Async async = context.async();
-    vertx.close(res -> {
-      if (res.failed()) {
-        logger.error("Failed to shut down edge-rtac server", res.cause());
-        fail(res.cause().getMessage());
-      } else {
-        logger.info("Successfully shut down edge-rtac server");
-      }
-
-      logger.info("Shutting down mock Okapi");
-      mockOkapi.close(context);
-      async.complete();
-    });
+    mockOkapi.close().onComplete(context.asyncAssertSuccess());
   }
 
   protected String prepareQueryFor(String apiKey, String... instanceIds) {
@@ -157,7 +142,7 @@ public class MainVerticleTest {
     assertEquals("\"OK\"", resp.body().asString());
   }
 
-  // unsuccessful login attempts result in a 200 OK status with empty elements 
+  // unsuccessful login attempts result in a 200 OK status with empty elements
   // in the message body
 
   @Test
@@ -218,8 +203,8 @@ public class MainVerticleTest {
     assertEquals("v.5:no.2-6", holdingRecord.getString("volume"));
   }
 
-  // Unsuccessful searches result in a 200 OK status with an empty element in the 
-  // response body 
+  // Unsuccessful searches result in a 200 OK status with an empty element in the
+  // response body
 
   @Test
   public void emptyResponseWhenTitleNotFound(TestContext context) throws Exception {
@@ -234,7 +219,7 @@ public class MainVerticleTest {
       .header(HttpHeaders.CONTENT_TYPE, APPLICATION_XML)
       .extract()
       .response();
-    
+
     expectEmptyResponseOnFailure(resp);
   }
 
@@ -386,9 +371,9 @@ public class MainVerticleTest {
         .header(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
         .extract()
         .response();
-      
+
       JsonObject result = new JsonObject(resp.body().asString());
-      
+
       assertEquals(titleId, result.getString("instanceId"));
 
       JsonObject holdings = result.getJsonArray("holdings").getJsonObject(0);
@@ -447,7 +432,7 @@ public class MainVerticleTest {
       .header(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
       .extract()
       .response();
-    
+
     final JsonObject actual = new JsonObject(resp.body().asString());
 
     assertEquals("0c8e8ac5-6bcc-461e-a8d3-4b55a96addc9", actual.getString("instanceId"));
@@ -471,7 +456,7 @@ public class MainVerticleTest {
     Holdings holdings = Instances.fromXml(responsePayload).getHoldings().get(0);
 
     assertEquals("0c8e8ac5-6bcc-461e-a8d3-4b55a96addc8", holdings.getInstanceId());
-    
+
     Holding holding = holdings.getHoldings().get(0);
 
     assertEquals("99712686103569", holding.id);

--- a/src/test/java/org/folio/edge/rtac/utils/RtacOkapiClientTest.java
+++ b/src/test/java/org/folio/edge/rtac/utils/RtacOkapiClientTest.java
@@ -52,7 +52,7 @@ public class RtacOkapiClientTest {
     knownTenants.add(tenant);
 
     mockOkapi = new RtacMockOkapi(okapiPort, knownTenants);
-    mockOkapi.start(context);
+    mockOkapi.start().onComplete(context.asyncAssertSuccess());
 
     client = new RtacOkapiClientFactory(Vertx.vertx(), "http://localhost:" + okapiPort, reqTimeout)
       .getRtacOkapiClient(tenant);
@@ -60,7 +60,7 @@ public class RtacOkapiClientTest {
 
   @After
   public void tearDown(TestContext context) {
-    mockOkapi.close(context);
+    mockOkapi.close().onComplete(context.asyncAssertSuccess());
   }
 
   @Test


### PR DESCRIPTION
Upgrade edge-common from 4.3.0 to 4.4.1.

This upgrades Vert.x from 4.3.1 to 4.3.3 fixing disabled SSL in WebClient:
https://github.com/vert-x3/wiki/wiki/4.3.2-Release-Notes#vertx-web

Upgrade vertx-stack-depchain from 4.3.1 to 4.3.3 to keep it in sync with the Vert.x version from edge-common.

Also upgrade log4j from 2.17.0 to 2.18.0 fixing Arbitrary Code Execution: https://nvd.nist.gov/vuln/detail/CVE-2021-44832

Fix mockOkapi Future usage, this is required for edge-common 4.4.*.
