### PR TITLE
Update aws-java-sdk to work with IMDSv2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-ssm</artifactId>
-      <version>1.11.313</version>
+      <version>1.12.462</version>
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>


### PR DESCRIPTION
Per [AWS doc](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/use-a-supported-sdk-version-for-imdsv2.html), `1.11.678` is the minimal version that supports AWS Instance Metadata Service Version 2.