### PR TITLE
EDGRTAC-82: Upgrade edge-common to get RTR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>4.4.3</version>
+      <version>4.5.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
https://issues.folio.org/browse/EDGRTAC-72

I believe this is all that is needed in order to get this edge module to use the RTR API.

`RtacHandler` calls `super.handleCommon` which after upgrading edge-common to `4.5.2` will obtain expiring tokens from the `authn/login-with-expiry` endpoint.