### PR TITLE
Add holdingsCopyNumber and ItemsCopyNumber to rtac response

### DIFF
--- a/ramls/batch-holdings.xsd
+++ b/ramls/batch-holdings.xsd
@@ -30,7 +30,8 @@
         <xs:element name="tempLocation" type="xs:string" minOccurs="0"/>
         <xs:element name="volume" type="xs:string" minOccurs="0"/>
         <xs:element name="temporaryLoanType" type="xs:string" minOccurs="0"/>
-        <xs:element name="permanentLoanType" type="xs:string" minOccurs="0"/>
+        <xs:element name="holdingsCopyNumber" type="xs:string" minOccurs="0"/>
+        <xs:element name="itemCopyNumber" type="xs:string" minOccurs="0"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/ramls/holdings.xsd
+++ b/ramls/holdings.xsd
@@ -20,6 +20,8 @@
       <xs:element name="dueDate" type="xs:string"/>
       <xs:element name="tempLocation" type="xs:string" minOccurs="0"/>
       <xs:element name="volume" type="xs:string" minOccurs="0"/>
+      <xs:element name="holdingsCopyNumber" type="xs:string" minOccurs="0"/>
+      <xs:element name="itemCopyNumber" type="xs:string" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>
 </xs:element>

--- a/src/main/java/org/folio/edge/rtac/model/Holding.java
+++ b/src/main/java/org/folio/edge/rtac/model/Holding.java
@@ -52,14 +52,11 @@ public final class Holding {
       Objects.equals(tempLocation, holding.tempLocation) &&
       Objects.equals(volume, holding.volume) &&
       Objects.equals(temporaryLoanType, holding.temporaryLoanType) &&
-      Objects.equals(permanentLoanType, holding.permanentLoanType) &&
-      Objects.equals(holdingsCopyNumber, holding.holdingsCopyNumber) &&
-      Objects.equals(itemCopyNumber, holding.itemCopyNumber);
+      Objects.equals(permanentLoanType, holding.permanentLoanType);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, callNumber, location, status, dueDate, tempLocation, volume, temporaryLoanType, permanentLoanType,
-        holdingsCopyNumber, itemCopyNumber);
+    return Objects.hash(id, callNumber, location, status, dueDate, tempLocation, volume, temporaryLoanType, permanentLoanType);
   }
 }

--- a/src/main/java/org/folio/edge/rtac/model/Holding.java
+++ b/src/main/java/org/folio/edge/rtac/model/Holding.java
@@ -34,6 +34,10 @@ public final class Holding {
   private final String temporaryLoanType;
   @JsonProperty("permanentLoanType")
   private final String permanentLoanType;
+  @JsonProperty("holdingsCopyNumber")
+  private final String holdingsCopyNumber;
+  @JsonProperty("itemCopyNumber")
+  private final String itemCopyNumber;
 
   @Override
   public boolean equals(Object o) {
@@ -48,11 +52,14 @@ public final class Holding {
       Objects.equals(tempLocation, holding.tempLocation) &&
       Objects.equals(volume, holding.volume) &&
       Objects.equals(temporaryLoanType, holding.temporaryLoanType) &&
-      Objects.equals(permanentLoanType, holding.permanentLoanType);
+      Objects.equals(permanentLoanType, holding.permanentLoanType) &&
+      Objects.equals(holdingsCopyNumber, holding.holdingsCopyNumber) &&
+      Objects.equals(itemCopyNumber, holding.itemCopyNumber);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, callNumber, location, status, dueDate, tempLocation, volume, temporaryLoanType, permanentLoanType);
+    return Objects.hash(id, callNumber, location, status, dueDate, tempLocation, volume, temporaryLoanType, permanentLoanType,
+        holdingsCopyNumber, itemCopyNumber);
   }
 }

--- a/src/main/java/org/folio/edge/rtac/model/Holding.java
+++ b/src/main/java/org/folio/edge/rtac/model/Holding.java
@@ -35,9 +35,9 @@ public final class Holding {
   @JsonProperty("permanentLoanType")
   private final String permanentLoanType;
   @JsonProperty("holdingsCopyNumber")
-  private final String holdingsCopyNumber;
+  public final String holdingsCopyNumber;
   @JsonProperty("itemCopyNumber")
-  private final String itemCopyNumber;
+  public final String itemCopyNumber;
 
   @Override
   public boolean equals(Object o) {

--- a/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/rtac/MainVerticleTest.java
@@ -201,6 +201,8 @@ public class MainVerticleTest {
     assertEquals("PS3552.E796 D44x 1975", holdingRecord.getString("callNumber"));
     assertEquals("Item in place", holdingRecord.getString("status"));
     assertEquals("v.5:no.2-6", holdingRecord.getString("volume"));
+    assertEquals("101", holdingRecord.getString("holdingsCopyNumber"));
+    assertEquals("201", holdingRecord.getString("itemCopyNumber"));
   }
 
   // Unsuccessful searches result in a 200 OK status with an empty element in the
@@ -262,6 +264,10 @@ public class MainVerticleTest {
     assertEquals("Item in place", secondHoldings.getString("status"));
     assertEquals("v.5:no.2-6", firstHoldings.getString("volume"));
     assertEquals("v.5:no.2-6", secondHoldings.getString("volume"));
+    assertEquals("101", firstHoldings.getString("holdingsCopyNumber"));
+    assertEquals("101", secondHoldings.getString("holdingsCopyNumber"));
+    assertEquals("201", firstHoldings.getString("itemCopyNumber"));
+    assertEquals("201", secondHoldings.getString("itemCopyNumber"));
   }
 
   @Test
@@ -463,6 +469,8 @@ public class MainVerticleTest {
     assertEquals("PS3552.E796 D44x 1975", holding.callNumber);
     assertEquals("Item in place", holding.status);
     assertEquals("v.5:no.2-6", holding.volume);
+    assertEquals("101", holding.holdingsCopyNumber);
+    assertEquals("201", holding.itemCopyNumber);
   }
 
   @Test

--- a/src/test/java/org/folio/edge/rtac/model/InstancesTest.java
+++ b/src/test/java/org/folio/edge/rtac/model/InstancesTest.java
@@ -41,6 +41,7 @@ public class InstancesTest {
       .status("Item in place")
       .dueDate("")
       .volume("v.10:no.2")
+      .itemCopyNumber("101")
       .build();
 
     Holding h2 = Holding.builder()
@@ -48,14 +49,25 @@ public class InstancesTest {
       .callNumber("PS3552.E796 D44x 1975")
       .location("LC General Collection Millersville University Library")
       .status("Item in place")
+      .holdingsCopyNumber("201")
       .dueDate("2018-04-23 12:00:00")
       .build();
+
+    Holding h3 = Holding.builder()
+        .id("99712686103569")
+        .callNumber("PS3552.E796 D44x 1975")
+        .location("LC General Collection Millersville University Library")
+        .status("Item in place")
+        .itemCopyNumber("102")
+        .holdingsCopyNumber("202")
+        .dueDate("2018-04-23 12:00:00")
+        .build();
 
     instances = new Instances();
 
     final var holdings = new Holdings();
     holdings.setInstanceId(INSTANCE_ID);
-    holdings.setHoldings(List.of(h1, h2));
+    holdings.setHoldings(List.of(h1, h2, h3));
     instances.setHoldings(List.of(holdings));
 
     SchemaFactory schemaFactory = SchemaFactory

--- a/src/test/java/org/folio/edge/rtac/utils/RtacMockOkapi.java
+++ b/src/test/java/org/folio/edge/rtac/utils/RtacMockOkapi.java
@@ -103,6 +103,8 @@ public class RtacMockOkapi extends MockOkapi {
       .tempLocation("")
       .dueDate("")
       .volume("v.5:no.2-6")
+      .holdingsCopyNumber("101")
+      .itemCopyNumber("201")
       .build();
 
     final var holdings = new Holdings();


### PR DESCRIPTION
## Purpose
Add holdings and itemCopyNumber to rtac response

- [jira ticket](https://folio-org.atlassian.net/browse/EDGRTAC-81)
- [dependent PR](https://github.com/folio-org/mod-rtac/pull/93)

## Approach
- Change FolioRtacMapper to add holdingsCopyNumber and itemCopyNumber 
- Change schema files